### PR TITLE
Abi

### DIFF
--- a/src/docs/swagger-generated.json
+++ b/src/docs/swagger-generated.json
@@ -1253,21 +1253,42 @@
     },
     "/api/curriculum/create": {
       "post": {
-        "description": "",
+        "tags": [
+          "Curriculum"
+        ],
+        "summary": "Crear curriculum",
+        "description": "Crea un nuevo curriculum",
         "responses": {
-          "default": {
-            "description": ""
+          "201": {
+            "description": "Curriculum creado correctamente"
+          },
+          "400": {
+            "description": "Datos inválidos"
           }
         },
         "security": [
           {
             "cookieAuth": []
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/curriculumSchema"
+              }
+            }
+          }
+        }
       }
     },
     "/api/curriculum/findByName/{name}": {
       "get": {
+        "tags": [
+          "Curriculum"
+        ],
+        "summary": "Buscar curriculum por nombre",
         "description": "",
         "parameters": [
           {
@@ -1280,8 +1301,18 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "Listado de curriculums",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/curriculumSchema"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1293,6 +1324,10 @@
     },
     "/api/curriculum/user/{userId}": {
       "get": {
+        "tags": [
+          "Curriculum"
+        ],
+        "summary": "Obtener curriculums por usuario",
         "description": "",
         "parameters": [
           {
@@ -1305,8 +1340,18 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "Curriculums del usuario",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/curriculumSchema"
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1318,6 +1363,10 @@
     },
     "/api/curriculum/update/{id}": {
       "put": {
+        "tags": [
+          "Curriculum"
+        ],
+        "summary": "Actualizar curriculum",
         "description": "",
         "parameters": [
           {
@@ -1330,19 +1379,33 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "Curriculum actualizado"
           }
         },
         "security": [
           {
             "cookieAuth": []
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/curriculumSchema"
+              }
+            }
+          }
+        }
       }
     },
     "/api/curriculum/delete/{id}": {
       "delete": {
+        "tags": [
+          "Curriculum"
+        ],
+        "summary": "Eliminar curriculum",
         "description": "",
         "parameters": [
           {
@@ -1355,8 +1418,8 @@
           }
         ],
         "responses": {
-          "default": {
-            "description": ""
+          "200": {
+            "description": "Curriculum eliminado"
           }
         },
         "security": [
@@ -2010,6 +2073,61 @@
         },
         "xml": {
           "name": "curriculumSchema"
+        }
+      },
+      "curriculumExample": {
+        "type": "object",
+        "properties": {
+          "nombre": {
+            "type": "string",
+            "example": "Juan"
+          },
+          "apellido": {
+            "type": "string",
+            "example": "Pérez"
+          },
+          "fecha_nacimiento": {
+            "type": "string",
+            "example": "1990-05-15"
+          },
+          "telefono": {
+            "type": "string",
+            "example": "123-456-7890"
+          },
+          "email": {
+            "type": "string",
+            "example": "juan.perez@example.com"
+          },
+          "ultimo_titulo": {
+            "type": "string",
+            "example": "Licenciado en Sistemas"
+          },
+          "experiencia": {
+            "type": "string",
+            "example": "3 años como desarrollador backend"
+          },
+          "habilidades_duras": {
+            "type": "string",
+            "example": "Node.js, PostgreSQL"
+          },
+          "habilidades_blandas": {
+            "type": "string",
+            "example": "Comunicación"
+          }
+        },
+        "required": [
+          "nombre",
+          "apellido",
+          "fecha_nacimiento",
+          "telefono",
+          "email",
+          "ultimo_titulo",
+          "experiencia",
+          "habilidades_duras",
+          "habilidades_blandas"
+        ],
+        "xml": {
+          "name": "curriculumExample"
         }
       },
       "mensajeSchema": {

--- a/src/docs/swagger-generated.json
+++ b/src/docs/swagger-generated.json
@@ -7,11 +7,83 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5000",
+      "url": "localhost",
       "description": ""
     }
   ],
   "paths": {
+    "/api/guest/login": {
+      "post": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Cookie response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/securitySchema"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/securitySchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/loginSchema"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/loginSchema"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/guest/register": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/registerSchema"
+              },
+              "example": {
+                "nombre_apellido": "Juan Pérez",
+                "email": "fulanchoΩ@example.com",
+                "contrasenia": "4123@examplE"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Tema/create": {
       "post": {
         "description": "",
@@ -670,78 +742,6 @@
         ]
       }
     },
-    "/api/guest/login": {
-      "post": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "Cookie response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/securitySchema"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/securitySchema"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "cookieAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/loginSchema"
-              }
-            },
-            "application/xml": {
-              "schema": {
-                "$ref": "#/components/schemas/loginSchema"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/guest/register": {
-      "post": {
-        "description": "",
-        "responses": {
-          "default": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "cookieAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/registerSchema"
-              },
-              "example": {
-                "nombre_apellido": "Juan Pérez",
-                "email": "fulanchoΩ@example.com",
-                "contrasenia": "4123@examplE"
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/carrera/create": {
       "post": {
         "description": "",
@@ -1250,6 +1250,121 @@
           }
         ]
       }
+    },
+    "/api/curriculum/create": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/api/curriculum/findByName/{name}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/api/curriculum/user/{userId}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/api/curriculum/update/{id}": {
+      "put": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/api/curriculum/delete/{id}": {
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1367,17 +1482,6 @@
               "contrasenia": {
                 "type": "object",
                 "properties": {
-                  "~guard": {
-                    "type": "object",
-                    "properties": {
-                      "check": {
-                        "type": "function"
-                      },
-                      "errors": {
-                        "type": "function"
-                      }
-                    }
-                  },
                   "passwordRules": {
                     "type": "array",
                     "items": {
@@ -1521,6 +1625,10 @@
                     "items": {
                       "type": "object",
                       "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "string"
+                        },
                         "const": {
                           "type": "string",
                           "example": "usuario"
@@ -1705,6 +1813,203 @@
         },
         "xml": {
           "name": "postSchema"
+        }
+      },
+      "curriculumSchema": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "example": "object"
+          },
+          "required": {
+            "type": "array",
+            "example": [
+              "nombre",
+              "apellido",
+              "fecha_nacimiento"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "nombre": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  }
+                }
+              },
+              "apellido": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  }
+                }
+              },
+              "fecha_nacimiento": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "format": {
+                    "type": "string",
+                    "example": "date"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de la fecha es inválido"
+                  }
+                }
+              },
+              "telefono": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato del teléfono es inválido"
+                  }
+                }
+              },
+              "email": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "format": {
+                    "type": "string",
+                    "example": "email"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato del email es inválido"
+                  }
+                }
+              },
+              "ultimo_titulo": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato del título es inválido"
+                  }
+                }
+              },
+              "experiencia": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de la experiencia es inválido"
+                  }
+                }
+              },
+              "habilidades_blandas": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de las habilidades blandas es inválido"
+                  }
+                }
+              },
+              "habilidades_duras": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de las habilidades duras es inválido"
+                  }
+                }
+              },
+              "idiomas": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de los idiomas es inválido"
+                  }
+                }
+              },
+              "presentacion": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de la presentación es inválido"
+                  }
+                }
+              },
+              "disponibilidad_horaria": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato de la disponibilidad horaria es inválido"
+                  }
+                }
+              },
+              "perfil_in": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "example": "string"
+                  },
+                  "errorMessage": {
+                    "type": "string",
+                    "example": "El formato del perfil de LinkedIn es inválido"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "xml": {
+          "name": "curriculumSchema"
         }
       },
       "mensajeSchema": {

--- a/src/docs/swagger-generated.json
+++ b/src/docs/swagger-generated.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "localhost",
+      "url": "http://localhost:5000",
       "description": ""
     }
   ],
@@ -1890,7 +1890,8 @@
             "example": [
               "nombre",
               "apellido",
-              "fecha_nacimiento"
+              "fecha_nacimiento",
+              "email"
             ],
             "items": {
               "type": "string"

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -6,7 +6,8 @@ import { TemaSchema } from '../schemas/Tema.schema.js';
 import { PostSchema } from '../schemas/Post.schemas.js';
 import { MensajeSchema } from '../schemas/Mensajes.schemas.js';
 import { ReporteSchema } from '../schemas/Reportes.schemas.js';
-import { CurriculumSchema } from 'schemas/Curriculum.schemas.js';	
+import { CurriculumSchema } from "../schemas/Curriculum.schemas.js";
+	
 
 const host = process.env.HOST
 

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -19,7 +19,7 @@ const doc = {
   },
   servers: [
     {
-      url: host,
+      url: `http://${host}:${process.env.PORT || 5000}`,
       description: "",
     },
   ],

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -12,50 +12,61 @@ import { CurriculumSchema } from "../schemas/Curriculum.schemas.js";
 const host = process.env.HOST
 
 const doc = {
-	info: {
-			version: 'v1.0.0',
-			title: 'Swagger Demo Project',
-			description: 'Implementation of Swagger with TypeScript'
-	},
-	servers: [
-			{
-					url: host,
-					description: ''
-			},
-	],
-	components: {
-		securitySchemes: {
-			cookieAuth: { 
-				type: 'apiKey',
-				in: 'cookie',
-				name: 'auth_token',
-			}
-		},
-		schemas: {
-				carreraSchema: CarreraSchema,
-				usuarioSchema: UsuarioSchema,
-				reportSchema: ReporteSchema,
-				temaSchema: TemaSchema,
-				postSchema: PostSchema,
-				curriculumSchema: CurriculumSchema,
-				mensajeSchema: MensajeSchema,
-				registerSchema: {
-						$email: 'fulanchoΩ@example.com',
-						$nombre_apellido: 'fula',
-						$contrasenia: '4123@examplE'
-				},
-				loginSchema: {
-						$email: 'fulanchoΩ@example.com',
-						$contrasenia: '4123@examplE'
-				}
-		},
-	},
-	security: [
-		{
-			cookieAuth: [],
-		},
-	],
-}
+  info: {
+    version: "v1.0.0",
+    title: "Swagger Demo Project",
+    description: "Implementation of Swagger with TypeScript",
+  },
+  servers: [
+    {
+      url: host,
+      description: "",
+    },
+  ],
+  components: {
+    securitySchemes: {
+      cookieAuth: {
+        type: "apiKey",
+        in: "cookie",
+        name: "auth_token",
+      },
+    },
+    schemas: {
+      carreraSchema: CarreraSchema,
+      usuarioSchema: UsuarioSchema,
+      reportSchema: ReporteSchema,
+      temaSchema: TemaSchema,
+      postSchema: PostSchema,
+      curriculumSchema: CurriculumSchema,
+      curriculumExample: {
+        $nombre: "Juan",
+        $apellido: "Pérez",
+        $fecha_nacimiento: "1990-05-15",
+        $telefono: "123-456-7890",
+        $email: "juan.perez@example.com",
+        $ultimo_titulo: "Licenciado en Sistemas",
+        $experiencia: "3 años como desarrollador backend",
+        $habilidades_duras: "Node.js, PostgreSQL",
+        $habilidades_blandas: "Comunicación",
+      },
+      mensajeSchema: MensajeSchema,
+      registerSchema: {
+        $email: "fulanchoΩ@example.com",
+        $nombre_apellido: "fula",
+        $contrasenia: "4123@examplE",
+      },
+      loginSchema: {
+        $email: "fulanchoΩ@example.com",
+        $contrasenia: "4123@examplE",
+      },
+    },
+  },
+  security: [
+    {
+      cookieAuth: [],
+    },
+  ],
+};
 
 
 

--- a/src/routes/Curriculum.routes.ts
+++ b/src/routes/Curriculum.routes.ts
@@ -4,23 +4,132 @@ import { createCurriculumController } from "../utils/factories/ClassFactory.js";
 const router = Router();
 const curriculumController = createCurriculumController();
 
+/**
+ * Crear curriculum
+ */
 router.post("/create", async (req: Request, res: Response) => {
+  /* #swagger.tags = ['Curriculum']
+     #swagger.summary = 'Crear curriculum'
+     #swagger.description = 'Crea un nuevo curriculum'
+     #swagger.requestBody = {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/curriculumSchema"
+            }
+          }
+        }
+     }
+     #swagger.responses[201] = {
+        description: 'Curriculum creado correctamente'
+     }
+     #swagger.responses[400] = {
+        description: 'Datos inválidos'
+     }
+  */
   await curriculumController.create(req, res);
 });
 
+/**
+ * Buscar curriculum por nombre
+ */
 router.get("/findByName/:name", async (req: Request, res: Response) => {
+  /* #swagger.tags = ['Curriculum']
+     #swagger.summary = 'Buscar curriculum por nombre'
+     #swagger.parameters['name'] = {
+        in: 'path',
+        required: true,
+        type: 'string'
+     }
+     #swagger.responses[200] = {
+        description: 'Listado de curriculums',
+        content: {
+          "application/json": {
+            schema: {
+              type: 'array',
+              items: {
+                $ref: "#/components/schemas/curriculumSchema"
+              }
+            }
+          }
+        }
+     }
+  */
   await curriculumController.findByName(req, res);
 });
 
+/**
+ * Obtener curriculums por usuario
+ */
 router.get("/user/:userId", async (req: Request, res: Response) => {
+  /* #swagger.tags = ['Curriculum']
+     #swagger.summary = 'Obtener curriculums por usuario'
+     #swagger.parameters['userId'] = {
+        in: 'path',
+        required: true,
+        type: 'number'
+     }
+     #swagger.responses[200] = {
+        description: 'Curriculums del usuario',
+        content: {
+          "application/json": {
+            schema: {
+              type: 'array',
+              items: {
+                $ref: "#/components/schemas/curriculumSchema"
+              }
+            }
+          }
+        }
+     }
+  */
   await curriculumController.findByUserId(req, res);
 });
 
+/**
+ * Actualizar curriculum
+ */
 router.put("/update/:id", async (req: Request, res: Response) => {
+  /* #swagger.tags = ['Curriculum']
+     #swagger.summary = 'Actualizar curriculum'
+     #swagger.parameters['id'] = {
+        in: 'path',
+        required: true,
+        type: 'number'
+     }
+     #swagger.requestBody = {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              $ref: "#/components/schemas/curriculumSchema"
+            }
+          }
+        }
+     }
+     #swagger.responses[200] = {
+        description: 'Curriculum actualizado'
+     }
+  */
   await curriculumController.update(req, res);
 });
 
+/**
+ * Eliminar curriculum
+ */
 router.delete("/delete/:id", async (req: Request, res: Response) => {
+  /* #swagger.tags = ['Curriculum']
+     #swagger.summary = 'Eliminar curriculum'
+     #swagger.parameters['id'] = {
+        in: 'path',
+        required: true,
+        type: 'number'
+     }
+     #swagger.responses[200] = {
+        description: 'Curriculum eliminado'
+     }
+  */
   await curriculumController.delete(req, res);
 });
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import guestRoutes from './Guest.routes.js';
 import carreraRoutes from './Carrera.routes.js';
 import mensajesRoutes from './Mensajes.routes.js';
 import reportRoutes from './Reportes.routes.js';
+import curriculumRoutes from './Curriculum.routes.js';
 import { authToken } from '../middleware/middleware_auth.js';
 
 
@@ -45,6 +46,12 @@ routes.use('/api/mensajes', mensajesRoutes
 ); // Assuming mensajes are handled by postRoutes
 routes.use('/api/reporte', reportRoutes
     /* #swagger.security = [{
+        "cookieAuth": []
+    }] */
+);
+routes.use(
+  "/api/curriculum", curriculumRoutes
+  /* #swagger.security = [{
         "cookieAuth": []
     }] */
 );

--- a/src/schemas/Curriculum.schemas.ts
+++ b/src/schemas/Curriculum.schemas.ts
@@ -4,7 +4,7 @@ export const CurriculumSchema = Type.Object({
     apellido: Type.String(),
     fecha_nacimiento: Type.String({format: 'date', errorMessage: 'El formato de la fecha es inválido'}),
     telefono: Type.Optional(Type.String({errorMessage: 'El formato del teléfono es inválido'})),
-    email: Type.Optional(Type.String ({format: 'email', errorMessage: 'El formato del email es inválido'})),
+    email: Type.String ({format: 'email', errorMessage: 'El formato del email es inválido'}),
     ultimo_titulo: Type.Optional(Type.String({errorMessage: 'El formato del título es inválido'})),
     experiencia: Type.Optional(Type.String({errorMessage: 'El formato de la experiencia es inválido'})),
     habilidades_blandas: Type.Optional(Type.String({errorMessage: 'El formato de las habilidades blandas es inválido'})),


### PR DESCRIPTION
## Summary by Sourcery

Document curriculum endpoints in Swagger and integrate curriculum routing into the main API routes.

New Features:
- Add Swagger documentation for curriculum CRUD endpoints, including request/response schemas and parameters.
- Expose curriculum API routes under the /api/curriculum path with cookie-based auth metadata.

Enhancements:
- Register Curriculum schema correctly in Swagger config and add an example curriculum object for documentation clarity.
- Reformat Swagger configuration for consistent style and fix Curriculum schema import path.